### PR TITLE
endless loop(?)

### DIFF
--- a/colormake
+++ b/colormake
@@ -7,9 +7,11 @@
 # on the screen.
 #
 
+MAKE=/usr/bin/make
+
 if [ "$TERM" = "dumb" ];then
    # As suggested by Alexander Korkov ...
-   exec make "$@"
+   exec $MAKE "$@"
 fi
 
 # Do we want truncated output?
@@ -28,9 +30,9 @@ if [ "$(basename $0 |cut -f1 -d-)" = "clmake" ]; then
     if [ -z "${CLMAKE_OPTS}" ]; then
         CLMAKE_OPTS='-SR -pError'
     fi
-    make "$@" 2>&1 | colormake.pl $SIZE |less ${CLMAKE_OPTS}
+    $MAKE "$@" 2>&1 | colormake.pl $SIZE |less ${CLMAKE_OPTS}
 else
-    make "$@" 2>&1 | colormake.pl $SIZE
+    $MAKE "$@" 2>&1 | colormake.pl $SIZE
 fi
 
 # Thanks to Alexander Korkov and Kolan Sh


### PR DESCRIPTION
Hey there!

I just encountered a problem using colormake (0.9-1) on Ubuntu 12.10:

When using colormake by creating a soft link to it called make
and then calling make, the fact that colormake itself uses the
relative 'make' causes en endless loop.

Is that a valid use-case or am I doing something wrong?

regards, lazlo
