### PR TITLE
Removing termination of "gcc" section for a `mv` that's run by `g++`

### DIFF
--- a/colormake.pl
+++ b/colormake.pl
@@ -69,12 +69,20 @@ $cols -= 19;
 
 $in = 'unknown';
 $| = 1;
+$skip = 0;
 while (<>)
 {
 	$orgline = $thisline = $_;
 
 	# Remove multiple spaces
 	$thisline =~ s/  \+/ /g;
+
+	# skip lines
+	$skip--;
+	if ($skip < 0)
+	{
+		$skip = 0;
+	}
 
 	# Truncate lines.
 	# I suppose this is bad, but it's better than what less does!
@@ -91,16 +99,23 @@ while (<>)
 	elsif ($thisline =~ s/^(\s*(libtool:\s*)?((compile|link):\s*)?(([[:ascii:]]+-)?g?(cc|\+\+)|(g|c)\+\+).*)$/$col_gcc$1$col_norm/)
 	{
 		$in = 'gcc';
+
+		if ($thisline =~ /\W-MF\W/)
+		{
+			$skip = 2;
+		}
 	}
 	elsif ($thisline =~ s/^\#/$col_comment#$1/x)
 	{
 		$in = 'comment';
 	}
-	elsif ($thisline =~ /^(\s*\(|\[|a(r|wk)|c(p|d|h(mod|own))|do(ne)?|e(cho|lse)|f(ind|or)|i(f|nstall)|mv|perl|r(anlib|m(dir)?)|s(e(d|t)|trip)|tar)\s+/)
+	elsif (!$skip && $thisline =~ /^(\s*\(|\[|a(r|wk)|c(p|d|h(mod|own))|do(ne)?|e(cho|lse)|f(ind|or)|i(f|nstall)|mv|perl|r(anlib|m(dir)?)|s(e(d|t)|trip)|tar)\s+/)
 	{
 		$in = $1;
 	}
-	elsif ($in eq 'gcc')
+	elsif ($in eq 'gcc'
+		&& $thisline !~ /^mv\W/
+		)
 	{
 		# Do interesting things if make is compiling something.
 


### PR DESCRIPTION
## Removing termination of "gcc" section for a `mv` that's run by `g++`
### Commit messages

because
- the `gcc` output should be colored
### Problem

The output from
- [test@john-peterson](https://github.com/john-peterson/Colormake/commits/test)

don't highlight `gcc` output in this command that use the [dependency output file](http://gcc.gnu.org/onlinedocs/cpp/Invocation.html) argument `-MF` because

the `mv` line terminate the `gcc` block

```
$ uname -a
CYGWIN_NT-6.1-WOW64 pc 1.7.18(0.263/5/3) 2013-04-19 10:39 i686 Cygwin

$ make
make  all-am
make[1]: Entering directory `/d/file/source/program/colormake/repo/test'
depbase=`echo src/test.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
g++ -DHAVE_CONFIG_H -I.      -g -O2 -Wall -MT src/test.o -MD -MP -MF $depbase.Tpo -c -o src/test.o src/test.cpp &&\
mv -f $depbase.Tpo $depbase.Po
src/test.cpp: In function ‘int main()’:
src/test.cpp:9:2: error: ‘error’ was not declared in this scope
src/test.cpp:11:2: error: expected ‘;’ before ‘return’
src/test.cpp:6:6: warning: unused variable ‘warning’
Makefile:314: recipe for target `src/test.o' failed
make[1]: *** [src/test.o] Error 1
make[1]: Leaving directory `/d/file/source/program/colormake/repo/test'
Makefile:200: recipe for target `all' failed
make: *** [all] Error 2
```

In another system the output is highlighted because

`mv` don't terminate the `gcc` block because it's not detected by the `$in = $1` regex comparison because it's indented

```
$ uname -a
Linux ubuntu12 3.2.0-45-generic #70-Ubuntu SMP Wed May 29 20:12:06 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux

$ make
make  all-am
make[1]: Entering directory `/mnt/hgfs/shared/source/program/colormake/repo/test'
depbase=`echo src/test.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
   g++ -DHAVE_CONFIG_H -I.     -g -O2 -Wall -MT src/test.o -MD -MP -MF $depbase.Tpo -c -o src/test.o src/test.cpp &&\
   mv -f $depbase.Tpo $depbase.Po
src/test.cpp: In function ‘int main()’:
src/test.cpp:9:2: error: ‘error’ was not declared in this scope
src/test.cpp:11:2: error: expected ‘;’ before ‘return’
src/test.cpp:6:6: warning: unused variable ‘warning’ [-Wunused-variable]
make[1]: *** [src/test.o] Error 1
make[1]: Leaving directory `/mnt/hgfs/shared/source/program/colormake/repo/test'
make: *** [all] Error 2
```

The output in color copied from `mintty` is in
- [test.rtf](https://www.dropbox.com/sh/2z5p162ovqtbn17/tq1wDIoQH4/file/colormake/test.rtf)
## Detect `-MF`

The test text and regex and for detecting `-MF` is

```
printf 'g++ -DHAVE_CONFIG_H -I.      -Wall -Wextra -O2 -g -MT src/test.o -MD -MP -MF $depbase.Tpo -c -o src/test.o src/test.cpp &&\' | perl -nE 'say /\W-MF\W/'
```
- it detect `g++` commands for which the first output line is a `mv` command
- it doesn't unintentionally detect lines that's not a `gcc` command because the text " -MF " is uncommon in such lines
## Detect `mv`

The test text and regex for detecting the `-MF` `mv` line is

printf 'mv -f $depbase.Tpo $depbase.Po' |  perl -nE 'say /^mv\W/'

because
- it remove color for `mv` commands because the command isn't important to highlight
- it doesn't unintentionally remove coloring for lines that should be colored
