### PR TITLE
Detecting `gcc` output without its command

### DIFF
--- a/colormake.pl
+++ b/colormake.pl
@@ -67,6 +67,9 @@ $lines = shift @ARGV || 0;
 $cols  = shift @ARGV || 0;
 $cols -= 19;
 
+$file = '[^\/?*:;{}\\\]+';
+$code_file = "$file\.(c|cpp|cc|hpp)";
+
 $in = 'unknown';
 $| = 1;
 while (<>)
@@ -88,7 +91,13 @@ while (<>)
 	{
 		$in = 'make';
 	}
-	elsif ($thisline =~ s/^(\s*(libtool:\s*)?((compile|link):\s*)?(([[:ascii:]]+-)?g?(cc|\+\+)|(g|c)\+\+).*)$/$col_gcc$1$col_norm/)
+	elsif ($thisline =~ s/^(
+	\s*(libtool:\s*)?
+	((compile|link):\s*)?
+	(([[:ascii:]]+-)?g?(cc|\+\+)|(g|c)\+\+).*
+	|$code_file
+	)$
+	/$col_gcc$1$col_norm/x)
 	{
 		$in = 'gcc';
 	}


### PR DESCRIPTION
## Detecting `gcc` output without its command
### Commit message

from a line that only contain a code file name

because
- some make files don't print the `gcc` command
### Problem

This make command doesn't print the code file name

```
$ uname -a
Linux ubuntu12 3.2.0-45-generic #70-Ubuntu SMP Wed May 29 20:12:06 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux

export DEVKITPRO=/opt/devkitpro
export DEVKITPPC=$DEVKITPRO/devkitPPC
sudo mkdir -p $DEVKITPRO
sudo chmod a+rwx $DEVKITPRO
cd Source/TestSuite
curl -Ls "https://sourceforge.net/p/devkitpro/perlupdaters/ci/master/tree/devkitPPCupdate.pl?format=raw" > devkitPPCupdate.pl
chmod +x devkitPPCupdate.pl
./devkitPPCupdate.pl
make -r

make[1]: Entering directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM'
dolphintest_aram.cpp
/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/source/dolphintest_aram.cpp:1:18: fatal error: aram.h: No such file or directory
compilation terminated.
make[2]: *** [dolphintest_aram.o] Error 1
make[1]: *** [build] Error 2
make[1]: Leaving directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM'
make: *** [all] Error 1
```
### Solution

Detecting `gcc` output from a line that only contain a code file name because
- that detect `gcc` output when the `gcc` command isn't printed and when the make file print the code file name on a line without other text
- don't unintentionally detect non-`gcc` output
### Confirm filename regex

Confirm this code

```
$file = '[^\/?*:;{}\\\]+';
```

because

I don't know why `\\` instead of `\\\` return

```
make
Unmatched [ in regex; marked by <-- HERE in m/^(
```
### `make -n`

`make -n` isn't a workaround because

it doesn't print the error line

```
$ make -nr
for i in `ls | egrep -v '^(CVS)$'`; do if test -e $i/Makefile ; then make -C $i || { exit 1;} fi; done;
make[1]: Entering directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM'
[ -d build ] || mkdir -p build
make --no-print-directory -C build -f /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/Makefile
echo dolphintest_aram.cpp
powerpc-eabi-g++ -MMD -MP -MF /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/build/dolphintest_aram.d -g -O2 -Wall -DGEKKO -mogc -mcpu=750 -meabi -mhard-float   -I/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/build -I/opt/devkitpro/libogc/include -c /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/source/dolphintest_aram.cpp -o dolphintest_aram.o
echo linking ... ARAM.elf
powerpc-eabi-g++  dolphintest_aram.o -g -DGEKKO -mogc -mcpu=750 -meabi -mhard-float -Wl,-Map,ARAM.elf.map  -L/opt/devkitpro/libogc/lib/cube -logc -lm -o /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/ARAM.elf
echo output ... ARAM.dol
elf2dol /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/ARAM.elf /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/ARAM.dol
make[1]: Leaving directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM'
make[1]: Entering directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ASM'
[ -d build ] || mkdir -p build
make --no-print-directory -C build -f /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ASM/Makefile
make[1]: Leaving directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ASM'
make[1]: Entering directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/AX'
[ -d build ] || mkdir -p build
make --no-print-directory -C build -f /mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/AX/Makefile
make: Entering an unknown directory
make: *** build: No such file or directory.  Stop.
make: Leaving an unknown directory
make[1]: *** [build] Error 2
make[1]: Leaving directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/AX'
make: *** [all] Error 1
```
### `make V=1`

`make V=1` isn't a workaround because

it doesn't have an effect in this make file

```
$ make -r V=1
user@ubuntu12:/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite$ make -r V=1
make[1]: Entering directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM'
dolphintest_aram.cpp
/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM/source/dolphintest_aram.cpp:1:18: fatal error: aram.h: No such file or directory
compilation terminated.
make[2]: *** [dolphintest_aram.o] Error 1
make[1]: *** [build] Error 2
make[1]: Leaving directory `/mnt/hgfs/shared/source2/dolphin/repo/Source/TestSuite/ARAM'
make: *** [all] Error 1
```
### Refactoring

The `gcc` block detection regex is refactored by
- making it multi-line

because
- it makes it faster to read
### Discussion

> The "?" belongs to the line before because it says the expression 0 or 1 time -> It belongs to the end of a line not the beginning

This is changed
