### PR TITLE
Add $COLORMAKE environment variable

### DIFF
--- a/colormake
+++ b/colormake
@@ -12,6 +12,9 @@ if [ "$TERM" = "dumb" ];then
    exec make "$@"
 fi
 
+# Set environment variable so that children can detect us
+export COLORMAKE=1
+
 # Do we want truncated output?
 if [ "$1" = "--short" ]; then
     SIZE=$(stty size)


### PR DESCRIPTION
Sets an environment variable (`$COLORMAKE`) to provide an easy way of testing if being wrapped by Colormake from the Makefile.

Example use-case:

```
.PHONY: shell
shell:
ifdef COLORMAKE
    $(warning Heads up: You might not be able to see the shell prompt through color highlighting)
endif
    docker run --rm $(DOCKER_FLAGS) -it $(DOCKER_NAME) bash
```
